### PR TITLE
fix: Form data filtering problem

### DIFF
--- a/clients/components/form-builder/linkages/default-value.ts
+++ b/clients/components/form-builder/linkages/default-value.ts
@@ -18,6 +18,7 @@ export function getFieldPath(linkageRulePath: string, fieldRealPath: string): st
 function fetchLinkedTableData$(
   getFieldValue: (path: string) => any,
   linkage: FormBuilder.DefaultValueLinkage,
+  isMultiple = false,
 ): Observable<Record<string, any>> {
   const rules: Rule[] = linkage.rules.map((rule) => {
     return operatorESParameter(
@@ -40,7 +41,7 @@ function fetchLinkedTableData$(
     }),
   ).pipe(
     catchError(() => of({ entities: [], total: 0 })),
-    map((res: FormDataListResponse) => res?.entities?.[0]),
+    map((res: FormDataListResponse) => isMultiple ? res?.entities : res?.entities?.[0]),
     filter((record) => !!record),
   );
 }
@@ -134,7 +135,6 @@ function findAllLinkages(schema: ISchema, subTableFieldName?: string): FormBuild
       const _linkage = subTableFieldName ? transformSubTableLinkage(linkage, subTableFieldName) : linkage;
       linkages.push(_linkage);
     }
-
     return linkages;
   }, []);
 }
@@ -143,8 +143,31 @@ type ExecuteLinkage = {
   linkage: FormBuilder.DefaultValueLinkage;
   formActions: ISchemaFormActions,
 }
-
-function executeLinkage({ linkage, formActions }: ExecuteLinkage): void {
+function getMultipleStatus(schema: ISchema, linkage: FormBuilder.DefaultValueLinkage): boolean {
+  const fieldId = linkage.targetField;
+  return schema.properties?.[fieldId]?.['x-component-props']?.multiple ?? false;
+}
+function getLinkedRows(linkedRow: Record<string, any> | undefined | any[],
+  linkage: FormBuilder.DefaultValueLinkage,
+  getFieldValue: (path: string) => any,
+  fieldRealPath?: string): any[] {
+  let linkedRows = [];
+  if (!Array.isArray(linkedRow)) {
+    linkedRows.push(linkedRow);
+  } else {
+    linkedRows = linkedRow;
+  }
+  const rows = linkedRows.map((linkedRow) => {
+    const shouldFire = shouldFireEffect({ linkedRow, linkage, getFieldValue });
+    if (shouldFire) {
+      return linkedRow;
+    }
+    return null;
+  }).filter(Boolean);
+  return [rows, fieldRealPath];
+}
+function executeLinkage(schema: ISchema, { linkage, formActions }: ExecuteLinkage): void {
+  const isMultiple = getMultipleStatus(schema, linkage);
   const { setFieldState, getFieldValue } = formActions;
   const listenedOnFields: string[] = [];
   linkage.rules.forEach((rule) => {
@@ -155,12 +178,12 @@ function executeLinkage({ linkage, formActions }: ExecuteLinkage): void {
 
   if (!listenedOnFields.length) {
     of(true).pipe(
-      switchMap(() => fetchLinkedTableData$(getFieldValue, linkage)),
-      filter((linkedRow) => shouldFireEffect({ linkedRow, linkage, getFieldValue })),
-    ).subscribe((linkedRow) => {
+      switchMap(() => fetchLinkedTableData$(getFieldValue, linkage, isMultiple)),
+      map((linkedRow) => getLinkedRows(linkedRow, linkage, getFieldValue)),
+    ).subscribe(([linkedRow]) => {
       logger.debug(`execute defaultValueLinkage on field: ${linkage.targetField}`);
       setFieldState(linkage.targetField, (state) => {
-        state.value = linkage.linkedField ? linkedRow[linkage.linkedField] : linkedRow;
+        state.value = linkage.linkedField ? linkedRow[0][linkage.linkedField] : linkedRow;
       });
     });
     return;
@@ -169,18 +192,18 @@ function executeLinkage({ linkage, formActions }: ExecuteLinkage): void {
   onFieldValueChange$(`*(${listenedOnFields.join(',')})`).pipe(
     debounceTime(200),
     filter((state) => shouldFetchLinkedTableData(getFieldValue, linkage, state.path)),
-    switchMap((state) => combineLatest([fetchLinkedTableData$(getFieldValue, linkage), of(state.path)])),
-    filter(([linkedRow]) => shouldFireEffect({ linkedRow, linkage, getFieldValue })),
+    switchMap((state) => combineLatest([fetchLinkedTableData$(getFieldValue, linkage, isMultiple), of(state.path)])),
+    map(([linkedRow, fieldRealPath]) => getLinkedRows(linkedRow, linkage, getFieldValue, fieldRealPath)),
   ).subscribe(([linkedRow, fieldRealPath]) => {
     logger.debug(`execute defaultValueLinkage on field: ${linkage.targetField}`);
     setFieldState(getFieldPath(linkage.targetField, fieldRealPath), (state) => {
-      state.value = linkage.linkedField ? linkedRow[linkage.linkedField] : linkedRow;
+      state.value = linkage.linkedField ? linkedRow[0][linkage.linkedField] : linkedRow;
     });
   });
 }
 
 export default function DefaultValueLinkageEffect(schema: ISchema, formActions: ISchemaFormActions): void {
   findAllLinkages(schema).forEach((linkage) => {
-    executeLinkage({ linkage, formActions });
+    executeLinkage(schema, { linkage, formActions });
   });
 }

--- a/clients/portal/modules/work-flow/content/editor/forms/update-table-data/index.tsx
+++ b/clients/portal/modules/work-flow/content/editor/forms/update-table-data/index.tsx
@@ -204,8 +204,8 @@ export default function UpdateTableData({
           <span className="text-body mr-10">更新对象:</span>
           <RadioButtonGroup
             listData={[
-              { label: '本表单数据', value: 'work-form' },
-              { label: '其它表单数据', value: 'others' },
+              { label: '本条数据', value: 'work-form' },
+              { label: '其它数据', value: 'others' },
             ]}
             onChange={(v) => {
               if (v === formType) return;


### PR DESCRIPTION
1/【表单引擎】关联数据在设置了多条关联规则时，只会带出其中一条数据
https://track.yunify.com/browse/LC-2459?filter=-1&jql=project%20%3D%20LC%20AND%20resolution%20%3D%20Unresolved%20AND%20assignee%20in%20(currentUser())%20order%20by%20updated%20DESC
2/修改流程-数据更新-更新对象(文字更改)