### PR TITLE
fix: Fix mouse enter move button set active but do not trigger validate

### DIFF
--- a/clients/components/form-builder/move-button.tsx
+++ b/clients/components/form-builder/move-button.tsx
@@ -1,25 +1,14 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { observer } from 'mobx-react';
 
-import { StoreContext } from '@c/form-builder/context';
 import Icon from '@c/icon';
 
 import './index.scss';
-type ReactMouseEvent = React.MouseEvent<HTMLDivElement, MouseEvent>;
 
 function MoveButton({ fieldId }: { fieldId: string }): JSX.Element {
-  const store = useContext(StoreContext);
-
-  const setActive = (e: ReactMouseEvent, fieldId: string): void => {
-    e.stopPropagation();
-    e.preventDefault();
-    store.setActiveFieldKey(fieldId);
-  };
-
   return (
     <div
       className='field-icon move-field-icon'
-      onMouseEnter={(e) => setActive(e, fieldId)}
     >
       <Icon name="drag" size={16} />
     </div >


### PR DESCRIPTION
# bugfix
1. 修复了当鼠标移入movebutton时会自动选中当移入的field而未触发之前选中的field的校验，修改为移入movebutton不会选中移入的field。