### PR TITLE
fix: Reset the page schema when canvas is unmounted

### DIFF
--- a/clients/portal/modules/apps-management/pages/page-design/blocks/canvas/index.tsx
+++ b/clients/portal/modules/apps-management/pages/page-design/blocks/canvas/index.tsx
@@ -11,6 +11,7 @@ import NodeRender from './node-render';
 import NodeToolbox from './node-toolbox';
 import { loadDevEnvPageArtery } from '../../utils/helpers';
 import { useStyle } from '../../hooks/use-style';
+import { initPageArtery } from '../../stores/page-helpers';
 
 import styles from './index.m.scss';
 import './style.scss';
@@ -37,6 +38,10 @@ function Canvas({ schema }: BlockItemProps<BlocksCommunicationType>): JSX.Elemen
     loadDevEnvPageArtery();
     // sync schema prop with store state
     schema && page.setSchema(schema as any);
+
+    return () => {
+      page.setSchema(initPageArtery());
+    };
   }, []);
 
   useStyle(


### PR DESCRIPTION
页面引擎在canvas卸载的时候，重置pageStore中的schema