### PR TITLE
fix: Fix userpicker crashed while filtering users with range

### DIFF
--- a/clients/components/form-builder/registry/user-picker/convertor.ts
+++ b/clients/components/form-builder/registry/user-picker/convertor.ts
@@ -61,9 +61,8 @@ export const toSchema = (config: DefaultConfig): ISchema => {
       onSearch(value: string) {
         config.onSearch && config.onSearch(value);
       },
-
-      filterOption: (input: string, option: Option) => {
-        return option.label.toLowerCase().indexOf(input.toLowerCase()) >= 0;
+      filterOption: (input: string, option: Option & { children: string[] }) => {
+        return option.children && option.children.join('').toLowerCase().indexOf(input.toLowerCase()) >= 0;
       },
     },
     ['x-internal']: {


### PR DESCRIPTION
# bugfix
【表单组件】在表单设计器中，人员组件设定了可选范围之后搜索会奔溃](https://track.yunify.com/browse/LC-2496)
【表单组件】表单人员组件在设置了可选范围的时候，搜索无效](https://track.yunify.com/browse/LC-2495)