### PR TITLE
fix: Es query rule error

### DIFF
--- a/clients/components/data-filter/utils.ts
+++ b/clients/components/data-filter/utils.ts
@@ -473,3 +473,19 @@ export function toFilterConfig(esObj: ESParameter): FilterConfig {
     condition,
   };
 }
+
+export interface QueryParamsType{
+  [key: string]: Rule[]
+}
+
+export function setESQueryParams(obj: QueryParamsType): QueryParamsType|{bool: QueryParamsType} {
+  Object.entries(obj).forEach(([key, val])=>{
+    if (!val.length) {
+      delete obj[key];
+    }
+  });
+  if (!Object.keys(obj).length) {
+    return {};
+  }
+  return { bool: obj };
+}

--- a/clients/components/form-builder/linkages/default-value.ts
+++ b/clients/components/form-builder/linkages/default-value.ts
@@ -1,11 +1,12 @@
 import { Observable, of, combineLatest } from 'rxjs';
 import { switchMap, debounceTime, filter, map, catchError } from 'rxjs/operators';
 import { from } from 'rxjs';
+import { mergeDeepRight } from 'ramda';
 import { FormEffectHooks, ISchemaFormActions } from '@formily/antd';
 
 import logger from '@lib/logger';
 import { fetchFormDataList, FormDataListResponse } from '@lib/http-client';
-import { operatorESParameter, Rule } from '@c/data-filter/utils';
+import { operatorESParameter, Rule, setESQueryParams, QueryParamsType } from '@c/data-filter/utils';
 import { compareOperatorMap } from '@c/form-builder/constants';
 
 const { onFieldValueChange$ } = FormEffectHooks;
@@ -33,17 +34,19 @@ function fetchLinkedTableData$(
       rule.valueFrom === 'fixedValue' ? rule.value as FormValue : getFieldValue(rule.value as string),
     );
   }) ?? [];
-  const query = {
-    bool: {
-      [linkage.ruleJoinOperator === 'every' ? 'must' : 'should']: rules,
-      [linkage.filterConfig?.tag as string]: filterRules,
-    },
+
+  const linkageRule = {
+    [linkage.ruleJoinOperator === 'every' ? 'must' : 'should']: rules.length > 0 ? rules : [],
+  };
+  const filterRule = {
+    [linkage.filterConfig?.tag as string]: filterRules.length > 0 ? filterRules : [],
   };
 
   return from(
     fetchFormDataList(linkage.linkedAppID, linkage.linkedTable.id, {
       sort: (linkage.linkedTableSortRules || []).filter(Boolean),
-      query,
+      query: setESQueryParams(mergeDeepRight(linkageRule, filterRule) as QueryParamsType),
+      size: 20,
     }),
   ).pipe(
     catchError(() => of({ entities: [], total: 0 })),
@@ -178,6 +181,7 @@ function executeLinkage(schema: ISchema, { linkage, formActions }: ExecuteLinkag
   const isMultiple = getMultipleStatus(schema, linkage);
   const { setFieldState, getFieldValue } = formActions;
   const listenedOnFields: string[] = [];
+  const linkedField = linkage.linkedField;
   linkage.rules.forEach((rule) => {
     if (rule.compareTo === 'currentFormValue') {
       listenedOnFields.push(rule.compareValue);
@@ -191,7 +195,7 @@ function executeLinkage(schema: ISchema, { linkage, formActions }: ExecuteLinkag
     ).subscribe(([linkedRow]) => {
       logger.debug(`execute defaultValueLinkage on field: ${linkage.targetField}`);
       setFieldState(linkage.targetField, (state) => {
-        state.value = linkage.linkedField ? linkedRow[0][linkage.linkedField] : getlinkedValData(linkedRow, isMultiple);
+        state.value = linkedField ? linkedRow[0][linkedField] : getlinkedValData(linkedRow, isMultiple);
       });
     });
     return;
@@ -205,7 +209,7 @@ function executeLinkage(schema: ISchema, { linkage, formActions }: ExecuteLinkag
   ).subscribe(([linkedRow, fieldRealPath]) => {
     logger.debug(`execute defaultValueLinkage on field: ${linkage.targetField}`);
     setFieldState(getFieldPath(linkage.targetField, fieldRealPath), (state) => {
-      state.value = linkage.linkedField ? linkedRow[0][linkage.linkedField] : getlinkedValData(linkedRow, isMultiple);
+      state.value = linkedField ? linkedRow[0][linkedField] : getlinkedValData(linkedRow, isMultiple);
     });
   });
 }


### PR DESCRIPTION
es查询修复;
1/如果bool下面的value为空数组/undefinde会报错500;
2/如果没有值bool及以下的对象都得删除

【关联记录】关联记录组件，在只读的时候，配置联动规则，只能默认带出10条数据
https://track.yunify.com/projects/LC/issues/LC-2519?filter=myopenissues