### PR TITLE
fix: The API proxy upload swagger does not display the error when the request fails

### DIFF
--- a/clients/portal/modules/apps-management/pages/app-details/api-key/index.tsx
+++ b/clients/portal/modules/apps-management/pages/app-details/api-key/index.tsx
@@ -17,6 +17,7 @@ import EmptyTips from '@c/empty-tips';
 
 import { createApiKey, getApiKeyList, updateApiKey, deleteApiKey, activeApiKey, getOneApiKey } from './api';
 import FormKeyMsg from './form-key-message';
+import OperationConfirm from './operation-confirm';
 
 import './index.scss';
 
@@ -307,17 +308,7 @@ function ApiKey(): JSX.Element {
             },
           ]}
         >
-          <div className='px-40 py-24'>
-            <div className='flex items-center mb-8'>
-              <Icon name='info' className='text-yellow-600' type='primary' size={18}/>
-              <span className='ml-10 text-14 text-yellow-600'>
-                确认要关闭吗？
-              </span>
-            </div>
-            <div className='pl-28'>
-              如果设置关闭状态后，会导致相关 API 请求失败。
-            </div>
-          </div>
+          <OperationConfirm message='关闭' tips='如果设置关闭状态后，会导致相关 API 请求失败。'/>
         </Modal>
       )}
       {showDelModal && (
@@ -340,17 +331,7 @@ function ApiKey(): JSX.Element {
             },
           ]}
         >
-          <div className='px-40 py-24'>
-            <div className='flex items-center mb-8'>
-              <Icon name='info' className='text-yellow-600' type='primary' size={18}/>
-              <span className='ml-10 text-14 text-yellow-600'>
-                确认要删除吗？
-              </span>
-            </div>
-            <div className='pl-28'>
-              如果该密钥被删除，将无法恢复。
-            </div>
-          </div>
+          <OperationConfirm message='删除' tips='如果该密钥被删除，将无法恢复。'/>
         </Modal>
       )}
       {showFormModal && (
@@ -364,7 +345,7 @@ function ApiKey(): JSX.Element {
               <div
                 className='flex items-center creat-api-key-tips bg-blue-100 text-blue-600 py-12 pl-18 mb-24'
               >
-                <Icon name='info' color='blue' className='w-16 h-16 fill-current' size={18}/>
+                <Icon name='info' className='w-16 h-16 fill-current' size={18}/>
                 <span className='ml-10 text-14'>
                   密钥新建成功，请务必妥善保存。该页面只存在一次，如有丢失请重新创建
                 </span>

--- a/clients/portal/modules/apps-management/pages/app-details/api-key/operation-confirm.tsx
+++ b/clients/portal/modules/apps-management/pages/app-details/api-key/operation-confirm.tsx
@@ -1,0 +1,25 @@
+import Icon from '@c/icon';
+import React from 'react';
+
+interface Props {
+  message: string,
+  tips: string,
+}
+
+function OperationConfirm({ message, tips }: Props): JSX.Element {
+  return (
+    <div className='px-40 py-24'>
+      <div className='flex items-center mb-8 text-yellow-600'>
+        <Icon name='info' type='primary' size={18}/>
+        <span className='ml-10 text-14'>
+          {`确认要${message}吗？`}
+        </span>
+      </div>
+      <div className='pl-28'>
+        {tips}
+      </div>
+    </div>
+  );
+}
+
+export default OperationConfirm;

--- a/clients/portal/modules/apps-management/pages/app-details/api-proxy/api-list/api-keys.tsx
+++ b/clients/portal/modules/apps-management/pages/app-details/api-proxy/api-list/api-keys.tsx
@@ -14,6 +14,7 @@ import toast from '@lib/toast';
 import ToolTip from '@c/tooltip';
 import EmptyTips from '@c/empty-tips';
 import Pagination from '@c/pagination';
+import OperationConfirm from '@portal/modules/apps-management/pages/app-details/api-key/operation-confirm';
 
 import CreatApiKeyTable from './creat-api-key-table';
 import store from '../store';
@@ -334,17 +335,7 @@ function ApiKeys(): JSX.Element {
             },
           ]}
         >
-          <div className='px-40 py-24'>
-            <div className='flex items-center mb-8'>
-              <Icon name='info' className='text-yellow-600' type='primary' size={18}/>
-              <span className='ml-10 text-14 text-yellow-600'>
-                确认要关闭吗？
-              </span>
-            </div>
-            <div className='pl-28'>
-              如果设置关闭状态后，会导致相关 API 请求失败。
-            </div>
-          </div>
+          <OperationConfirm message='关闭' tips='如果设置关闭状态后，会导致相关 API 请求失败。'/>
         </Modal>
       )}
       {showDelModal && (
@@ -367,17 +358,7 @@ function ApiKeys(): JSX.Element {
             },
           ]}
         >
-          <div className='px-40 py-24'>
-            <div className='flex items-center mb-8'>
-              <Icon name='info' className='text-yellow-600' type='primary' size={18}/>
-              <span className='ml-10 text-14 text-yellow-600'>
-                确认要删除吗？
-              </span>
-            </div>
-            <div className='pl-28'>
-              如果该密钥被删除，将无法恢复。
-            </div>
-          </div>
+          <OperationConfirm message='删除' tips='如果该密钥被删除，将无法恢复。'/>
         </Modal>
       )}
     </div>

--- a/clients/portal/modules/apps-management/pages/app-details/api-proxy/api-list/list.tsx
+++ b/clients/portal/modules/apps-management/pages/app-details/api-proxy/api-list/list.tsx
@@ -16,6 +16,7 @@ import toast from '@lib/toast';
 import Pagination from '@c/pagination';
 import { copyToClipboard } from '@lib/utils';
 import ToolTip from '@c/tooltip';
+import OperationConfirm from '@portal/modules/apps-management/pages/app-details/api-key/operation-confirm';
 
 import { deleteNativeApi, activeApi } from '../api';
 import { useNamespace } from '../hooks';
@@ -277,19 +278,8 @@ function ApiList(): JSX.Element {
             },
           ]}
         >
-          <div className='px-40 py-24'>
-            <div className='flex items-center mb-8'>
-              <Icon name='info' className='text-yellow-600' type='primary' size={18}/>
-              <span className='ml-10 text-14 text-yellow-600'>
-                {modalType === 'disable' && '确认要关闭吗？'}
-                {modalType === 'delete' && '确认要删除吗？'}
-              </span>
-            </div>
-            <div className='pl-28'>
-              {modalType === 'disable' && '如果设置关闭状态后，会导致相关 API 请求失败。'}
-              {modalType === 'delete' && '如果该 API 被删除，将无法恢复。'}
-            </div>
-          </div>
+          {modalType === 'disable' && <OperationConfirm message='关闭' tips='如果设置关闭状态后，会导致相关 API 请求失败。'/>}
+          {modalType === 'delete' && <OperationConfirm message='删除' tips='如果该 API 被删除，将无法恢复。'/>}
         </Modal>
       )}
     </div>

--- a/clients/portal/modules/apps-management/pages/app-details/api-proxy/api.ts
+++ b/clients/portal/modules/apps-management/pages/app-details/api-proxy/api.ts
@@ -101,7 +101,13 @@ export function uploadSwagger(body: any): Promise<PolyAPI.CreateApiResult> {
     body: body,
   }).then((response) => {
     return response.json();
-  }).then((res) => res.data);
+  }).then(({ code, msg, data }) => {
+    if (code !== 0) {
+      return Promise.reject(new Error(msg));
+    }
+
+    return data;
+  });
 }
 
 export const getNamespaceApiList = async (namespacePath: string, params: Paging): Promise<{


### PR DESCRIPTION
1.修复第三方API代理上传swagger文件失败时前端未提示错误信息；  
2.修复了API代理和API密钥图标颜色未按设置显示的问题。