### PR TITLE
fix: Linkage rule data is retrieved at one time

### DIFF
--- a/clients/components/form-builder/linkages/default-value.ts
+++ b/clients/components/form-builder/linkages/default-value.ts
@@ -46,7 +46,7 @@ function fetchLinkedTableData$(
     fetchFormDataList(linkage.linkedAppID, linkage.linkedTable.id, {
       sort: (linkage.linkedTableSortRules || []).filter(Boolean),
       query: setESQueryParams(mergeDeepRight(linkageRule, filterRule) as QueryParamsType),
-      size: 20,
+      size: 200,
     }),
   ).pipe(
     catchError(() => of({ entities: [], total: 0 })),

--- a/clients/components/form-builder/registry/associated-records/associated-records/index.tsx
+++ b/clients/components/form-builder/registry/associated-records/associated-records/index.tsx
@@ -87,6 +87,7 @@ function AssociatedRecords({
         columns={tableColumns}
         data={value}
         emptyTips="没有关联记录"
+        style={{ maxHeight: 300 }}
       />
       {!readOnly && (
         <Button type="button" onClick={() => setShowSelectModal(true)}>选择关联记录</Button>


### PR DESCRIPTION
【关联记录】关联记录组件，在只读的时候，配置联动规则，只能默认带出10条数据
https://track.yunify.com/projects/LC/issues/LC-2519?filter=doneissues

解决:
1.限制搜索size为200
2.限制table最大高度为300px,超出内容可滚动