### PR TITLE
fix: The API proxy data is not cleared when switching applications

### DIFF
--- a/clients/portal/modules/apps-management/pages/app-details/api-proxy/api-list/index.tsx
+++ b/clients/portal/modules/apps-management/pages/app-details/api-proxy/api-list/index.tsx
@@ -9,6 +9,7 @@ import ApiList from './list';
 import GroupSetting from './group-setting';
 import ApiKeys from './api-keys';
 import NoData from '../comps/no-data';
+import { useNamespace } from '../hooks';
 
 import store from '../store';
 
@@ -42,6 +43,7 @@ function renderApiListTips(): JSX.Element | string {
 }
 
 function ListPage(): JSX.Element {
+  const ns = useNamespace();
   const [tabKey, setTabKey] = useState(defaultKey);
   const tabs = useMemo(()=> {
     return [
@@ -65,7 +67,7 @@ function ListPage(): JSX.Element {
   }, [store.currentNs?.id, store.svc?.fullPath, store.svc?.authType, store.apiKeyTotal]);
 
   useEffect(()=> {
-    store.fetchSvc().then(() => {
+    ns && store.fetchSvc().then(() => {
       if (!store.svc) {
         setTabKey('group-setting');
       } else if (store.svc.authType === 'signature' && !store.apiKeyTotal) {
@@ -74,7 +76,7 @@ function ListPage(): JSX.Element {
         setTabKey(defaultKey);
       }
     });
-  }, [store.currentSvcPath]);
+  }, [ns]);
 
   return (
     <>

--- a/clients/portal/modules/apps-management/pages/app-details/api-proxy/index.tsx
+++ b/clients/portal/modules/apps-management/pages/app-details/api-proxy/index.tsx
@@ -23,6 +23,8 @@ function ApiProxy(): JSX.Element | null {
   useEffect(()=> {
     store.setAppId(appID);
     store.fetchNamespaces(appID);
+
+    return store.reset;
   }, []);
 
   if (!store.treeStore && store.isInitSuccessed) {


### PR DESCRIPTION
1.切换应用时未清除上一个应用第三方API数据（ https://track.yunify.com/browse/LC-2542 ）