### PR TITLE
fix: Restore a wrapper div which has a fixed height in appland

### DIFF
--- a/clients/app-land/app-land.tsx
+++ b/clients/app-land/app-land.tsx
@@ -6,5 +6,9 @@ import { ARTERY_KEY_VERSION } from '@portal/constants';
 import { rootSchemaKey } from './utils';
 
 export default function AppLand(): JSX.Element {
-  return <ArteryRenderer arteryID={rootSchemaKey} version={ARTERY_KEY_VERSION} />;
+  return (
+    <div style={{ height: '100vh', overflow: 'auto' }}>
+      <ArteryRenderer arteryID={rootSchemaKey} version={ARTERY_KEY_VERSION} />
+    </div>
+  );
 }


### PR DESCRIPTION
修复应用上下布局高度塌陷的样式问题，给appland增加一个wrapper div并且加上固定高度100vh