### PR TITLE
fix: Rich text and file upload and value transfer modification

### DIFF
--- a/clients/components/quill/options.ts
+++ b/clients/components/quill/options.ts
@@ -11,8 +11,8 @@ const modules = {
 
     [{ size: ['small', false, 'large', 'huge'] }],
     [{ header: [1, 2, 3, 4, 5, 6, false] }],
-    // ['link', 'image', 'video'],
-    ['link', 'video'],
+    // ['link', 'image'],
+    ['link'],
     [{ color: [] }, { background: [] }],
 
     ['clean'],


### PR DESCRIPTION
【流程邮件】邮件节点中添加video组件和附件文件，邮箱邮件中没收到这些数据
https://track.yunify.com/projects/LC/issues/LC-2561?filter=myopenissues
邮件有限制字数提示
https://track.yunify.com/projects/LC/issues/LC-2566?filter=myopenissues

解决:
1/iframe标签在接受邮件页面会把src替换成_src,富文本中删除video上次,改成下面的附件上传(已跟产品说好了的)
2/附件上传方式改成公开
3/富文本和图片内容大小不能超过5kb