### PR TITLE
fix: Registry appID in applang template

### DIFF
--- a/clients/components/simple-view-render/external-view-render.tsx
+++ b/clients/components/simple-view-render/external-view-render.tsx
@@ -6,7 +6,7 @@ type Props = {
 }
 
 export default function ExternalViewRender({ name, link }: Props): JSX.Element {
-  const appID = window.APPID;
+  const appID = window.APP_ID;
   function realizeLink(link: string): string {
     const replacements: Record<string, string> = {
       user_id: window.USER.id,

--- a/clients/components/task-lists/unread-task-box/task-item.tsx
+++ b/clients/components/task-lists/unread-task-box/task-item.tsx
@@ -3,6 +3,7 @@ import cs from 'classnames';
 import dayjs from 'dayjs';
 import { observer } from 'mobx-react';
 import { Progress } from 'antd';
+import { useParams } from 'react-router-dom';
 
 import Icon from '@c/icon';
 import { getQuery } from '@lib/utils';
@@ -50,7 +51,7 @@ function TaskItem({ task, deleteTaskItem }: Props): JSX.Element {
   const refItem = useRef(null);
 
   const { pageID } = getQuery<{ pageID: string }>();
-  const appID = window.APPID;
+  const appID = window.APP_ID ?? useParams<{appID: string}>().appID;
 
   function getIcon(): string {
     if (IMPORT_TYPE.includes(command) && (status === 3 || status === 1)) return 'upload-apps';

--- a/clients/templates/appLand.html
+++ b/clients/templates/appLand.html
@@ -14,7 +14,7 @@
     window.USER_ADMIN_ROLES = {{ .userAdminRoles }}
     window.CONFIG = {{ .CONFIG }}
     window.__verbose_log__ = {{ .debugMode }}
-    window.APPID = {{ .appID }}
+    window.APP_ID = {{ .appID }}
     window.SIDE = 'home';
   </script>
   {{template "_jsEntry" .}}

--- a/server/pkg/portal/handlers/app_land.go
+++ b/server/pkg/portal/handlers/app_land.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"path"
 	"qxp-web/server/pkg/contexts"
-	
+
 	"github.com/gorilla/mux"
 )
 
@@ -32,6 +32,6 @@ func AppLandHandler(w http.ResponseWriter, r *http.Request) {
 		"userAdminRoles":    userAdminRoles,
 		"debugMode":         contexts.Config.DevMode,
 		"CONFIG":            contexts.Config.ClientConfig,
-		"appID":						 appID,
+		"appID":             appID,
 	})
 }


### PR DESCRIPTION
将APPID注册到app-land渲染模版中，更新home端任务列表组件、外部链接页面中获取appID的方式