### PR TITLE
fix: By default, only 10 associated records can be displayed

### DIFF
--- a/clients/components/form-builder/form-settings-panel/form-field-config/default-value-linkage-config-btn.tsx
+++ b/clients/components/form-builder/form-settings-panel/form-field-config/default-value-linkage-config-btn.tsx
@@ -8,7 +8,7 @@ import { INTERNAL_FIELD_NAMES } from '@c/form-builder/store';
 import { FieldConfigContext } from '@c/form-builder/form-settings-panel/form-field-config/context';
 
 import LinkageConfig from './default-value-linkage-config';
-
+import './index.scss';
 function DefaultValueLinkageConfigBtn(props: ISchemaFieldComponentProps): JSX.Element {
   const store = useContext(StoreContext);
   const { actions } = useContext(FieldConfigContext);
@@ -32,6 +32,7 @@ function DefaultValueLinkageConfigBtn(props: ISchemaFieldComponentProps): JSX.El
   return (
     <>
       <Button onClick={() => setShowModal(true)}>设置联动规则</Button>
+      <span className='linkage-config-tips'>最多支持999条</span>
       {
         showModal && (
           <LinkageConfig

--- a/clients/components/form-builder/form-settings-panel/form-field-config/index.scss
+++ b/clients/components/form-builder/form-settings-panel/form-field-config/index.scss
@@ -23,3 +23,8 @@
   border-radius: 8px 8px 0 0;
   background: var(--gray-100);
 }
+.linkage-config-tips{
+  font-size: 12px;
+  color:var(--gray-300);
+  margin-left: 6px;
+}

--- a/clients/components/form-builder/linkages/default-value.ts
+++ b/clients/components/form-builder/linkages/default-value.ts
@@ -37,6 +37,7 @@ function fetchLinkedTableData$(
   return from(
     fetchFormDataList(linkage.linkedAppID, linkage.linkedTable.id, {
       sort: (linkage.linkedTableSortRules || []).filter(Boolean),
+      size: 999,
       query,
     }),
   ).pipe(

--- a/clients/components/form-builder/registry/associated-records/associated-records/index.tsx
+++ b/clients/components/form-builder/registry/associated-records/associated-records/index.tsx
@@ -87,6 +87,7 @@ function AssociatedRecords({
         columns={tableColumns}
         data={value}
         emptyTips="没有关联记录"
+        style={{ maxHeight: 300 }}
       />
       {!readOnly && (
         <Button type="button" onClick={() => setShowSelectModal(true)}>选择关联记录</Button>


### PR DESCRIPTION
线上环境:
 关联记录数据只显示10条的问题