### PR TITLE
refactor: Restore app right layout 

### DIFF
--- a/clients/app-land/index.scss
+++ b/clients/app-land/index.scss
@@ -1,5 +1,11 @@
 [data-layout-type="header-content"] {
-  @apply flex flex-col h-full overflow-auto;
+  @apply flex flex-col h-full overflow-auto flex-shrink-0;
+
+  [data-layout-child="fragment-container"] {
+    max-height: 80px;
+    max-width: none;
+    overflow: auto;
+  }
 
   [data-layout-child="routes-container"] {
     @apply flex-1 overflow-auto;
@@ -7,7 +13,7 @@
 }
 
 [data-layout-type="right-sidebar-content"] {
-  @apply flex flex-row-reverse h-full overflow-auto;
+  @apply flex flex-row-reverse h-full overflow-auto flex-shrink-0;
 
   [data-layout-child="routes-container"] {
     @apply flex-1 overflow-auto;
@@ -15,9 +21,15 @@
 }
 
 [data-layout-type="left-sidebar-content"] {
-  @apply flex h-full overflow-auto;
+  @apply flex h-full overflow-auto flex-shrink-0;
 
   [data-layout-child="routes-container"] {
     @apply flex-1 bg-blue-50 overflow-auto;
   }
+}
+
+[data-layout-child="fragment-container"] {
+  max-width: 120px;
+  max-height: none;
+  overflow: auto;
 }


### PR DESCRIPTION
1. Restore app-land right layout, because it has been used in page layout
2. Add max width or height style for app fragment-container